### PR TITLE
Fix preview notes/walls crash #8

### DIFF
--- a/src/note.cpp
+++ b/src/note.cpp
@@ -3,6 +3,7 @@
 #include "GlobalNamespace/ColorNoteVisuals.hpp"
 #include "GlobalNamespace/ILazyCopyHashSet_1.hpp"
 #include "GlobalNamespace/NoteData.hpp"
+#include "GlobalNamespace/NoteController.hpp"
 #include "UnityEngine/MaterialPropertyBlock.hpp"
 #include "UnityEngine/MeshFilter.hpp"
 #include "UnityEngine/MeshRenderer.hpp"
@@ -404,8 +405,13 @@ UnityEngine::Transform* CustomModels::PreviewNotes(UnityEngine::Vector3 position
         GetDefaultBomb()->transform->SetParent(preview, false);
     } else {
         auto parent = GetDefaultNotes()->transform;
-        ColorDefaultNotes(parent, MenuLeftColor(), MenuRightColor());
         parent->SetParent(preview, false);
+
+        for (auto noteController : parent->GetComponentsInChildren<GlobalNamespace::NoteController*>()) {
+            UnityEngine::Object::DestroyImmediate(noteController);
+        }
+
+        ColorDefaultNotes(parent, MenuLeftColor(), MenuRightColor());
     }
 
     RemoveLoadingGuard();

--- a/src/wall.cpp
+++ b/src/wall.cpp
@@ -3,6 +3,7 @@
 #include "GlobalNamespace/ObstacleMaterialSetter.hpp"
 #include "GlobalNamespace/SettingsManager.hpp"
 #include "GlobalNamespace/StretchableObstacle.hpp"
+#include "GlobalNamespace/ObstacleController.hpp"
 #include "UnityEngine/MeshFilter.hpp"
 #include "UnityEngine/MeshRenderer.hpp"
 #include "UnityEngine/Renderer.hpp"
@@ -156,6 +157,10 @@ UnityEngine::Transform* CustomModels::PreviewWalls(UnityEngine::Vector3 position
     } else {
         auto instance = GetDefaultWall()->transform;
         instance->SetParent(preview, false);
+
+        for (auto obstacleController : instance->GetComponentsInChildren<GlobalNamespace::ObstacleController*>()) {
+            UnityEngine::Object::DestroyImmediate(obstacleController);
+        }
 
         auto stretch = instance->GetComponent<GlobalNamespace::StretchableObstacle*>();
         stretch->SetAllProperties(scale.x, scale.y, scale.z, MenuWallColor(), 0);


### PR DESCRIPTION
Fixes a crash that would occur when a default note or wall preview was created, and NE or Chroma was installed.

An instantiation of the default note or wall prefab will include the `NoteController` / `ObstacleController` scripts. These scripts are not designed to run in the main menu scene, and `NoteController::Update` would lead to a null reference exception in `NoteWaiting::ShouldWait`. Unity C# would catch this error and pipe it to logcat, preventing the game from crashing but still creating an unstable system.

When NE or Chroma hooks `NoteController`, the call stack is placed within a C++ exception handler, which is programmed to crash when it detects an error. It is also unable to read the C# error message, hence the mysterious crash.

Removing `NoteController` and `ObstacleController` from the preview models will prevent the GameCore-only code from running, stop the C# exception, stop the C++ exception handler from crashing, and even stopping NE/Chroma from attempting to hook the preview objects.

Note: This only fixes one of the two NE/Chroma + Custom Model preview crashes. The other issue is caused by NE/Chroma only updating the "is modchart" variable while reading custom map data (leaving it true even after GameCore ends) and will be addressed in NE and Chroma.